### PR TITLE
[enh] make output image oultlined and same size

### DIFF
--- a/cut-to-pieces.py
+++ b/cut-to-pieces.py
@@ -17,7 +17,7 @@ def paths_to_images(image, drawable, path):
     for id in vectors:
         vector = gimp.Vectors.from_id(id)
         pdb.gimp_image_select_item(image, 2, vector)
-        pdb.gimp_edit_stroke_vectors(drawable, vector)
+        pdb.gimp_edit_stroke(drawable)
         e, x1, y1, x2, y2 = pdb.gimp_selection_bounds(image)
         width = x2 - x1
         height = y2 - y1

--- a/cut-to-pieces.py
+++ b/cut-to-pieces.py
@@ -18,11 +18,6 @@ def paths_to_images(image, drawable, path):
         vector = gimp.Vectors.from_id(id)
         pdb.gimp_image_select_item(image, 2, vector)
         pdb.gimp_edit_stroke_vectors(drawable, vector)
-        n_e = False
-        x1 = None
-        y1 = None
-        x2 = None
-        y2 = None
         e, x1, y1, x2, y2 = pdb.gimp_selection_bounds(image)
         width = x2 - x1
         height = y2 - y1


### PR DESCRIPTION
To facilitate the printing and the cutting of the pieces, I've update the plugin to provide two thing:
1. The pieces are outlined to facilitate the cutting on paper afterwards
2. The generated pieces have the same size to be sure that there is no scaling issue when printing